### PR TITLE
Remove import for network.dart

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fusionauth_game/game_screen.dart';
 import 'package:fusionauth_game/login_screen.dart';
-import 'package:fusionauth_game/network.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
Hey Dedan! The client requested for the import to be removed from the base code and a note to be added in the article asking the readers to import the file once they create it. I've made the changes in the doc, I just need you to merge this PR to remove the import from the file. Please feel free to let me know if you have any questions!